### PR TITLE
blueth(#17): AsyncEventLoop interface impl with epoll and tests

### DIFF
--- a/blueth/concurrency/AsyncEventLoop.hpp
+++ b/blueth/concurrency/AsyncEventLoop.hpp
@@ -2,6 +2,7 @@
 #include "internal/EventLoopBase.hpp"
 #include "io/IOBuffer.hpp"
 #include "net/Socket.hpp"
+#include <asm-generic/errno-base.h>
 #include <asm-generic/errno.h>
 #include <cassert>
 #include <cstdint>
@@ -9,114 +10,172 @@
 #include <cstdlib>
 #include <errno.h>
 #include <exception>
+#include <iostream>
 #include <memory>
-#include <new>
 #include <stdexcept>
+#include <string>
 #include <sys/epoll.h>
 #include <unistd.h>
 
+#define CAST_TO_PEERSTATEHOLDER_PTR(pointer) ((PeerStateHolder *)(pointer))
+#define CAST_TO_VOID_PTR(pointer) ((void *)(pointer))
+#define CAST_TO_PEERSTATE_PTR(pointer) ((PeerState *)pointer)
+
 namespace blueth::concurrency {
 
-/// Used with the factory function when creating a new Event-Loop object
-enum class EventLoopImpl : std::uint8_t { Epoll };
-
-/**
- * This is the object which will be used by a user when we pass the pointer.
- * When an accept event occured, we pass this object to the registered callbacks
- * and the user must modify the peer_state_ which is type PeerStateHolder to
- * their own custom implementations. We only store the pointer. We free() the
- * pointer when we exit. So the user must also use an object with similar
- * symentics.
- *
- * TODO: What if a user have a complex object which have it's own delete
- * symentics? Can we make them to pass a shared_ptr? Or some other mechanism to
- * allow them to manage their own memory?
- */
 template <typename PeerState>
-class PeerStateHolder final : public PeerStateHolderBase<PeerState> {
+class AsyncEpollEventLoop final
+    : public EventLoopBase<PeerState>,
+      public std::enable_shared_from_this<AsyncEpollEventLoop<PeerState>> {
       public:
-	PeerStateHolder() {}
-	int getFD() override { return fd_; }
-	void setFD(int fd) override { fd_ = fd; }
-	PeerState *getPeerStatePtr() override { return peer_state_; }
-	void setPeerStatePtr(PeerState *ptr) override { peer_state_ = ptr; }
-
-      private:
-	int fd_;
-	PeerState *peer_state_{nullptr};
-};
-
-template <typename PeerState>
-class AsyncEpollEventLoop final : public EventLoopBase<PeerState> {
-      public:
-	AsyncEpollEventLoop(int non_blocking_server_sock,
-			    size_t num_event_size) noexcept(false);
-	void registerCallbackForEvent(
-	    std::function<FDStatus(PeerStateHolderBase<PeerState> *)>,
-	    EventType) noexcept(false) override;
-	void removePeerFromWatchlist(PeerStateHolderBase<PeerState> *) noexcept(
-	    false) override{};
-	void startEventloop() noexcept(false) override;
-	void modifyEventForPeer(PeerStateHolderBase<PeerState> *) noexcept(
-	    false) override {}
-
-      private:
-	int server_sock_;
-	int epoll_fd_;
-	size_t max_events_supported_;
-	epoll_event accept_event_;
-	epoll_event *events_;
-	std::function<FDStatus(PeerStateHolderBase<PeerState> *)>
-	    on_accept_callback_;
-	std::function<FDStatus(PeerStateHolderBase<PeerState> *)>
-	    on_read_callback_;
-	std::function<FDStatus(PeerStateHolderBase<PeerState> *)>
-	    on_write_callback_;
-};
-
-template <typename PeerState>
-static std::unique_ptr<EventLoopBase<PeerState>>
-EventLoopFactory(EventLoopImpl event_loop, int sock_fd = 0,
-		 size_t num_events = 0) {
-	if (event_loop == EventLoopImpl::Epoll) {
-		return std::make_unique<AsyncEpollEventLoop<PeerState>>(
-		    sock_fd, num_events);
+	using HandlerCallbackType =
+	    typename EventLoopBase<PeerState>::HandlerCallbackType;
+	template <typename T1, typename T2, typename T3, typename T4,
+		  typename T5>
+	static std::shared_ptr<EventLoopBase<PeerState>>
+	create(T1 server_address, T2 server_port, T3 event_loop_size,
+	       T4 server_backlog, T5 timeout) {
+		return std::make_shared<AsyncEpollEventLoop<PeerState>>(
+		    std::move(server_address), std::move(server_port),
+		    std::move(event_loop_size), std::move(server_backlog),
+		    std::move(timeout));
 	}
-	throw std::invalid_argument(
-	    "invalid argument to EventLoopFactory function");
+	AsyncEpollEventLoop(std::string server_address,
+			    std::uint16_t server_port, size_t num_event_size,
+			    int server_backlog, int timeout) noexcept(false);
+	void
+	registerCallbackForEvent(HandlerCallbackType callback_fn,
+				 EventType event_type) noexcept(false) override;
+	void startEventloop() noexcept(false) override;
+	int writeToPeer(PeerStateHolder *peer_state_holder,
+			std::shared_ptr<io::IOBuffer<char>>
+			    io_buffer) noexcept(false) override;
+	int readFromPeer(PeerStateHolder *peer_state_holder,
+			 std::shared_ptr<io::IOBuffer<char>>
+			     io_buffer) noexcept(false) override;
+	~AsyncEpollEventLoop();
+
+      protected:
+	void epollAddToWatchlist(int fd, PeerStateHolder *peer_state,
+				 std::uint32_t event) noexcept(false);
+	void modifyEventForPeer(int fd, PeerStateHolder *peer_state,
+				std::uint32_t event) noexcept(false);
+	void
+	removePeerFromWatchlist(int fd,
+				PeerStateHolder *peer_state) noexcept(false);
+	void addPeerToWatchlist(int fd, PeerStateHolder *peer_state,
+				std::uint32_t event) noexcept(false);
+	std::shared_ptr<EventLoopBase<PeerState>>
+	getSharedPtr() noexcept override {
+		return this->shared_from_this();
+	}
+
+      private:
+	void epollErrorHandler_(int return_code, const char *str) const
+	    noexcept(false);
+
+      private:
+	net::Socket socket_;
+	int epoll_fd_;
+	int timeout_;
+	size_t max_events_supported_;
+	bool epoll_setup_done_{false};
+	epoll_event *events_;
+	HandlerCallbackType on_accept_callback_;
+	HandlerCallbackType on_read_callback_;
+	HandlerCallbackType on_write_callback_;
+};
+
+template <typename PeerState>
+void AsyncEpollEventLoop<PeerState>::epollAddToWatchlist(
+    int fd, PeerStateHolder *peer_state, std::uint32_t event) noexcept(false) {
+	epoll_event ev;
+	ev.events = event;
+	ev.data.ptr = peer_state;
+	if (epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, fd, &ev) < 0) {
+		std::perror("epoll_ctl");
+		throw std::runtime_error{"epoll_ctl"};
+	}
 }
 
-// clang-format off
 template <typename PeerState>
-AsyncEpollEventLoop<PeerState>::AsyncEpollEventLoop(
-    int non_blocking_server_sock, size_t max_events_supported) noexcept(false)
-    : server_sock_{non_blocking_server_sock}, 
-      max_events_supported_{max_events_supported} {
+void AsyncEpollEventLoop<PeerState>::epollErrorHandler_(int return_code,
+							const char *str) const
+    noexcept(false) {
+	if (return_code < 0) {
+		std::perror(str);
+		throw std::runtime_error{""};
+	}
+}
+
+template <typename PeerState>
+void AsyncEpollEventLoop<PeerState>::removePeerFromWatchlist(
+    int fd, PeerStateHolder *peer_state) noexcept(false) {
+	epoll_event ev; // Kernel version < 2.6.9 compatibility
+	ev.events = 0;
+	if (epoll_ctl(epoll_fd_, EPOLL_CTL_DEL, fd, &ev) < 0) {
+		std::perror("epoll_ctl");
+		throw std::runtime_error{"epoll_ctl"};
+	}
+}
+
+template <typename PeerState>
+void AsyncEpollEventLoop<PeerState>::addPeerToWatchlist(
+    int fd, PeerStateHolder *peer_state, std::uint32_t event) noexcept(false) {
+	epoll_event ev;
+	ev.events = event;
+	ev.data.ptr = CAST_TO_VOID_PTR(peer_state);
+	int ret = epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, fd, &ev);
+	epollErrorHandler_(ret, "epoll_ctl");
+}
+
+template <typename PeerState>
+void AsyncEpollEventLoop<PeerState>::modifyEventForPeer(
+    int fd, PeerStateHolder *peer_state, std::uint32_t event) noexcept(false) {
+	epoll_event ev;
+	ev.events = event;
+	ev.data.ptr = CAST_TO_VOID_PTR(peer_state);
+	int ret = epoll_ctl(epoll_fd_, EPOLL_CTL_MOD, fd, &ev);
+	epollErrorHandler_(ret, "epoll_ctl");
+}
+
+template <typename PeerState>
+AsyncEpollEventLoop<PeerState>::AsyncEpollEventLoop(std::string server_address,
+						    std::uint16_t server_port,
+						    size_t max_events_supported,
+						    int server_backlog,
+						    int timeout) noexcept(false)
+    : socket_{std::move(server_address), server_port, server_backlog,
+	      net::Domain::Ipv4, net::SockType::Stream},
+      max_events_supported_{max_events_supported}, timeout_{timeout} {
+
+	socket_.makeSocketNonBlocking();
+	socket_.bindSock();
 	epoll_fd_ = ::epoll_create1(0);
-	if (epoll_fd_ == -1) {
-		std::perror("epoll_create1");
-		throw std::runtime_error("epoll_create1");
-	}
-	accept_event_.events = EPOLLIN;
-	accept_event_.data.ptr = new PeerStateHolder<PeerState>();
-	((PeerStateHolder<PeerState>*)(accept_event_.data.ptr))->setFD(server_sock_);
-	if (::epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, server_sock_, &accept_event_)) {
-		std::perror("epoll_ctl EPOLL_CTL_ADD");
-		throw std::runtime_error("epoll_ctl EPOLL_CTL_ADD");
-	}
+	epollErrorHandler_(epoll_fd_, "epoll_create1");
+
+	PeerStateHolder *peer_state = new PeerStateHolder();
+	peer_state->setFileDescriptor(socket_.getFileDescriptor());
+	peer_state->setPeerState(new PeerState());
+	epollAddToWatchlist(socket_.getFileDescriptor(), peer_state, EPOLLIN);
 	events_ =
-	    (epoll_event*)calloc(max_events_supported_, sizeof(epoll_event));
+	    (epoll_event *)calloc(max_events_supported_, sizeof(epoll_event));
 	if (events_ == nullptr) {
 		std::perror("calloc()");
 		throw std::bad_alloc();
 	}
+	epoll_setup_done_ = true;
 }
-// clang-format on
+
+template <typename PeerState>
+AsyncEpollEventLoop<PeerState>::~AsyncEpollEventLoop() {
+	::close(epoll_fd_);
+	::free(events_);
+}
 
 template <typename PeerState>
 void AsyncEpollEventLoop<PeerState>::registerCallbackForEvent(
-    std::function<FDStatus(PeerStateHolderBase<PeerState> *)> callback,
-    EventType event) noexcept(false) {
+    HandlerCallbackType callback, EventType event) noexcept(false) {
 	if (event == EventType::ReadEvent) {
 		on_write_callback_ = std::move(callback);
 	} else if (event == EventType::WriteEvent) {
@@ -129,75 +188,129 @@ void AsyncEpollEventLoop<PeerState>::registerCallbackForEvent(
 	}
 }
 
+template <typename PeerState>
+int AsyncEpollEventLoop<PeerState>::writeToPeer(
+    PeerStateHolder *peer_state_holder,
+    std::shared_ptr<io::IOBuffer<char>> io_buffer) noexcept(false) {
+	PeerState *peer_state =
+	    CAST_TO_PEERSTATE_PTR(peer_state_holder->getPeerState());
+	if (!io_buffer)
+		throw std::runtime_error{
+		    "Invalid IOBuffer passed onto the writeToPeer handler"};
+	if (!io_buffer->getDataSize()) return 0;
+	std::size_t num_bytes_to_send = io_buffer->getDataSize();
+	int send_ret =
+	    ::send(peer_state_holder->getFileDescriptor(),
+		   io_buffer->getStartOffsetPointer(), num_bytes_to_send, 0);
+	if (send_ret < 0) {
+		if (errno == EAGAIN || errno == EWOULDBLOCK) {
+			return 0;
+		} else {
+			std::perror("send()");
+			throw std::runtime_error{""};
+		}
+	}
+	io_buffer->modifyStartOffset(num_bytes_to_send);
+	return num_bytes_to_send;
+}
+
+template <typename PeerState>
+int AsyncEpollEventLoop<PeerState>::readFromPeer(
+    PeerStateHolder *peer_state_holder,
+    std::shared_ptr<io::IOBuffer<char>> io_buffer) noexcept(false) {
+	if (!io_buffer)
+		throw std::runtime_error{
+		    "Invalid IOBuffer passed onto the readFromPeer handler"};
+	if (!io_buffer->getAvailableSpace()) return 0;
+	int recv_ret = ::recv(peer_state_holder->getFileDescriptor(),
+			      io_buffer->getStartOffsetPointer(),
+			      io_buffer->getAvailableSpace(), 0);
+	if (recv_ret < 0) {
+		if (errno == EAGAIN || errno == EWOULDBLOCK) {
+			return 0;
+		} else {
+			std::perror("recv()");
+			throw std::runtime_error{""};
+		}
+	}
+	io_buffer->modifyEndOffset(recv_ret);
+	return recv_ret;
+}
+
 // clang-format off
 template <typename PeerState>
 void AsyncEpollEventLoop<PeerState>::startEventloop() noexcept(false) {
 	for (;;) {
-		// TODO: Make the user specify the timeout value
 		int nready =
-		    ::epoll_wait(epoll_fd_, events_, max_events_supported_, -1);
-		for (size_t i{}; i < nready; ++i) {
-			if (events_[i].events & EPOLLIN) {
-				if (((PeerStateHolder<PeerState>*)(events_[i].data.ptr))->getFD() == server_sock_) {
-					struct sockaddr_in sock_addr;
-					socklen_t sockaddr_len = sizeof(struct sockaddr_in);
-					int client_sock = accept(server_sock_, (struct sockaddr *)&sock_addr, &sockaddr_len);
-					if (client_sock < 0) {
-						// Very rare so, let's log it
-						if (errno == EAGAIN || errno == EWOULDBLOCK) {
-							printf("accept returned EAGAIN and EWOULDBLOCK");
-							continue;
-						}else{
-							std::perror("accept");
-							throw std::runtime_error("accept()");
-						}
-					}
-					net::makeSocketNonBlocking(client_sock);
-					epoll_event event = {0};
-					PeerStateHolder<PeerState> *peer_state = new PeerStateHolder<PeerState>();
-					peer_state->setFD(client_sock);
-					FDStatus on_accept = this->on_accept_callback_(peer_state);
-					event.data.ptr = peer_state;
-					if(on_accept.want_read) event.events |= EPOLLIN;
-					if(on_accept.want_write) event.events |= EPOLLOUT;
-					if(event.events == 0){
-						this->removePeerFromWatchlist(peer_state);
+		    epoll_wait(epoll_fd_, events_, max_events_supported_, timeout_);
+		if (!nready) break;
+		epollErrorHandler_(nready, "epoll_wait");
+		for (int peer_index{}; peer_index < nready; peer_index++) {
+			if (CAST_TO_PEERSTATEHOLDER_PTR(events_[peer_index].data.ptr)->getFileDescriptor() ==
+			    socket_.getFileDescriptor()) {
+				// New incomming connection
+				// @@@ Currently we only support IPv4 for the event loop
+				sockaddr_in peer_addr;
+				socklen_t peer_addr_len = sizeof(peer_addr);
+				int client_fd = ::accept(
+				    socket_.getFileDescriptor(), (struct sockaddr *)&peer_addr, &peer_addr_len);
+				if (client_fd < 0) {
+					if (errno == EAGAIN ||
+					    errno == EWOULDBLOCK) {
+						fprintf(stderr, "accept EAGAIN or EWOULDBLOCK");
 						continue;
-					}
-					if(::epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, client_sock, &event) < 0){
-						std::perror("epoll_ctl EPOLL_CTL_ADD");
-						throw std::runtime_error("epoll_ctl");
-					}
-				}else{
-					FDStatus read_return = this->on_read_callback_((PeerStateHolder<PeerState>*)events_[i].data.ptr);
-					int peer_fd = ((PeerStateHolder<PeerState>*)events_[i].data.ptr)->getFD();
-					epoll_event event = {0};
-					event.data.ptr = events_[i].data.ptr;	
-					if(read_return.want_read) event.events |= EPOLLIN;
-					if(read_return.want_write) event.events |= EPOLLOUT;
-					if(event.events == 0){
-						this->removePeerFromWatchlist((PeerStateHolder<PeerState>*)events_[i].data.ptr);
-						continue;
-					}
-					if(::epoll_ctl(epoll_fd_, EPOLL_CTL_MOD, peer_fd, &event) < 0){
-						std::perror("epoll_ctl EPOLL_CTL_MOD");
-						throw std::runtime_error("epoll_ctl EPOLL_CTL_MOD");
+					} else {
+						std::perror("accept");
+						throw std::runtime_error{""};
 					}
 				}
-			}else if(events_[i].events & EPOLLOUT){
-				FDStatus read_return = this->on_write_callback_((PeerStateHolder<PeerState>*)events_[i].data.ptr);
-				int peer_fd = ((PeerStateHolder<PeerState>*)events_[i].data.ptr)->getFD();
-				epoll_event event = {0};
-				event.data.ptr = events_[i].data.ptr;
-				if(read_return.want_read) event.events |= EPOLLIN;
-				if(read_return.want_write) event.events |= EPOLLOUT;
-				if(event.events == 0){
-					this->removePeerFromWatchlist((PeerStateHolder<PeerState>*)events_[i].data.ptr);
-					continue;
+				PeerStateHolder *peer_state =
+				    new PeerStateHolder();
+				peer_state->setFileDescriptor(client_fd);
+				peer_state->setPeerState(new PeerState());
+				make_socketnonblocking(client_fd);
+				std::shared_ptr<EventLoopBase<PeerState>> ev_loop = this->getSharedPtr();
+				FDStatus fd_status =
+				    on_accept_callback_(peer_state, ev_loop);
+				std::uint32_t events{};
+				if (fd_status.want_read) events |= EPOLLIN;
+				if (fd_status.want_write) events |= EPOLLOUT;
+				struct epoll_event event;
+				event.events = events;
+				event.data.ptr = CAST_TO_VOID_PTR(peer_state);
+				int ret = epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, client_fd, &event);
+				epollErrorHandler_(ret, "epoll_ctl");
+			} else if (events_[peer_index].events & EPOLLIN) {
+				PeerStateHolder *peer_state = 
+					CAST_TO_PEERSTATEHOLDER_PTR(events_[peer_index].data.ptr);
+				std::shared_ptr<EventLoopBase<PeerState>> ev_loop = this->getSharedPtr();
+				FDStatus fd_status = on_read_callback_(peer_state, ev_loop);
+				std::uint32_t events{};
+				if (fd_status.want_read) events |= EPOLLIN;
+				if (fd_status.want_write) events |= EPOLLOUT;
+				if (!events) {
+					close(peer_state->getFileDescriptor());
+					delete CAST_TO_PEERSTATE_PTR(CAST_TO_PEERSTATEHOLDER_PTR(
+								events_[peer_index].data.ptr)->getPeerState());
+					delete CAST_TO_PEERSTATEHOLDER_PTR(events_[peer_index].data.ptr);
+				} else {
+					modifyEventForPeer(peer_state->getFileDescriptor(), peer_state, events);
 				}
-				if(::epoll_ctl(epoll_fd_, EPOLL_CTL_MOD, peer_fd, &event)){
-					std::perror("epoll_ctl EPOLL_CTL_MOD");
-					throw std::runtime_error("epoll_ctl EPOLL_CTL_ADD");
+			} else if (events_[peer_index].events & EPOLLOUT) {
+				PeerStateHolder *peer_state = 
+					CAST_TO_PEERSTATEHOLDER_PTR(events_[peer_index].data.ptr);
+				std::shared_ptr<EventLoopBase<PeerState>> ev_loop = this->getSharedPtr();
+				FDStatus fd_status = on_write_callback_(peer_state, ev_loop);
+				std::uint32_t events{};
+				if (fd_status.want_read) events |= EPOLLIN;
+				if (fd_status.want_write) events |= EPOLLOUT;
+				if (!events) {
+					close(peer_state->getFileDescriptor());
+					delete CAST_TO_PEERSTATE_PTR(CAST_TO_PEERSTATEHOLDER_PTR(
+								events_[peer_index].data.ptr)->getPeerState());
+					delete CAST_TO_PEERSTATEHOLDER_PTR(events_[peer_index].data.ptr);
+				} else {
+					modifyEventForPeer(peer_state->getFileDescriptor(), peer_state, events);
 				}
 			}
 		}

--- a/blueth/concurrency/internal/EventLoopBase.hpp
+++ b/blueth/concurrency/internal/EventLoopBase.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "io/IOBuffer.hpp"
 #include <cstdio>
 #include <cstdlib>
 #include <fcntl.h>
@@ -47,62 +48,124 @@ static void make_socketnonblocking(int socket_fd) noexcept {
 }
 
 /**
- * A user must inherit this class and override the two functions, because these
- * will be used by our event-dispatch handlers to remove/add a file-descriptor
- * from watch list
+ * This is the object which the client uses to hold the peer-state object, it
+ * might a raw/smart pointer. It's generic, PeerState template, since we leave
+ * it upto the user to handle that however they wish. They must use this
+ * interface since the internal implementations of the event loop depends on the
+ * file descriptor's pointer when an event occures for that particular network
+ * socket FD. Since most implementations of event loop uses `union` which
+ * restricts us to storing either a pointer or a FD. But since storing FD within
+ * a global array is very expensive and waste of the stack memory usage, we'd
+ * use the pointer to handle that.
  */
-template <typename PeerState> class PeerStateHolderBase {
+class PeerStateHolder {
       public:
+	PeerStateHolder() = default;
+	~PeerStateHolder() = default;
+	int getFileDescriptor() const noexcept { return fd_; }
+	void setFileDescriptor(int fd) noexcept { fd_ = fd; }
 	/**
-	 * Get a File-Descriptor
-	 *
-	 * We use this getter and setter for the file-descriptor for
-	 * PeerState when we need to add/remove an it from the watch-list
-	 * @return FD which is for this current peer
+	 * We'll store the remote peer's state of type PeerState which a user
+	 * may use to handle the network requests/responses. We'll pass this as
+	 * the argument to the network handlers that are registered during the
+	 * initilization of the EventLoop implementation. Expected expected type
+	 * of PeerState is either a raw or smart pointer(since they might also
+	 * pass a unique_ptr which have ownership semantics), we use std::move
+	 * to take of that.
 	 */
-	virtual int getFD() = 0;
-	/**
-	 * Set a File-Descriptor
-	 *
-	 * We use this when we first accept a connection and allocate a object
-	 * for the peer.
-	 *
-	 * @param fd File descriptor value to set.
-	 */
-	virtual void setFD(int fd) = 0;
-	/**
-	 * Get a PeerState, which is a pointer to the object which stores the
-	 * Peer's state.
-	 *
-	 * This will be used by the user if they need to manage the
-	 * pointers/objects which maintains the state
-	 * @return Pointer(or smart_pointer) to object which store this peer's
-	 * state
-	 */
-	virtual PeerState *getPeerStatePtr() = 0;
-	/**
-	 * Set a Peer's state. This is useful when we first allocate the object
-	 * itself or if we use a smart_pointer which have ownership symentics so
-	 * we need to use the std::move
-	 *
-	 * @param ptr The pointer to object(This class does not mange the
-	 * life-time of that object, unless it's a smart pointer which does when
-	 * this class dies.)
-	 */
-	virtual void setPeerStatePtr(PeerState *ptr) = 0;
+	void *getPeerState() const noexcept { return std::move(peer_state_); }
+	void setPeerState(void *peer_state) noexcept {
+		peer_state_ = std::move(peer_state);
+	}
+
+      private:
+	int fd_;
+	void *peer_state_;
 };
 
+/**
+ * The base EventLoopBase is the interface class for the various eventloop
+ * abstraction implementations like linux specific epoll or select and so on.
+ * Every implementation should support the pure virtual handlers of
+ * EventLoopBase which will be used by the users for their code. PeerState is
+ * the generic type which a user can specify. It's generally a raw pointer or a
+ * smart pointer. It's passed into the callbacks on various events when the file
+ * descriptor is ready for read/write/accept events and networking IO
+ * operations. PeerState is used to hold user-defined state information like the
+ * protocol parser's state and such.
+ */
 template <typename PeerState> class EventLoopBase {
       public:
-	virtual void registerCallbackForEvent(
-	    std::function<FDStatus(PeerStateHolderBase<PeerState> *)>,
-	    EventType) noexcept(false) = 0;
-	virtual void removePeerFromWatchlist(
-	    PeerStateHolderBase<PeerState> *) noexcept(false) = 0;
-	virtual void modifyEventForPeer(
-	    PeerStateHolderBase<PeerState> *) noexcept(false) = 0;
+	using HandlerCallbackType = std::function<FDStatus(
+	    PeerStateHolder *, std::shared_ptr<EventLoopBase<PeerState>>)>;
+
+	/**
+	 * Register callbacks for various events like when a file descriptor is
+	 * ready for networking IO (read or write) and when a new peer is trying
+	 * connect.
+	 *
+	 * @param callback The callback function (either a functor or a raw
+	 * function pointer) which should be invoked when a specific event
+	 * happenes.
+	 * @param event_type Register the callback for the specific event.
+	 */
+	virtual void
+	registerCallbackForEvent(HandlerCallbackType callback,
+				 EventType event_type) noexcept(false) = 0;
+	/**
+	 * Start the event loop and start processing the requests (assuming all
+	 * the callbacks on the events are already set) If the callbacks are not
+	 * set at the time of calling this function, an exception of type
+	 * std::runtime_error is thrown.
+	 */
 	virtual void startEventloop() noexcept(false) = 0;
+	/**
+	 * Write the data in the io_buffer into the remote peer pointed by
+	 * peer_fd in a non-blocking way on wire. Returns the amount of bytes
+	 * written and raises an exception on failur.
+	 *
+	 * @param peer_state_holder PeerStateHolder object which contains all
+	 * the context information for the write handler to send byte onto the
+	 * non-blocking socket
+	 * @param io_buffer Bytes to write to the remote peer
+	 * @return Total number of bytes written
+	 */
+	virtual int writeToPeer(
+	    PeerStateHolder *peer_state_holder, std::shared_ptr<io::IOBuffer<char>> io_buffer) noexcept(false) = 0;
+	/**
+	 * Read raw from the wire sent by the remote peer and store it in-place
+	 * into the io_buffer. There is zero-copy involved from reading from the
+	 * wire and storing it into the io_buffer
+	 *
+	 * The readFromPeer will try to read number of bytes equal to the total
+	 * space available on the buffer. If a user needs to read more content
+	 * than the size of the buffer, they must manually resize the IOBuffer
+	 * on their end.
+	 *
+	 * @param peer_state_holder PeerStateHolder object which contains all
+	 * the context information needed for reading bytes off the non-blocking
+	 * socket of the remote peer
+	 * @param io_buffer Pointer to IOBuffer object to store the read bytes
+	 * from the wire in-place
+	 * @return Total number of bytes read from the remote peer
+	 */
+	virtual int readFromPeer(
+	    PeerStateHolder *peer_state_holder, std::shared_ptr<io::IOBuffer<char>> io_buffer) noexcept(false) = 0;
 	virtual ~EventLoopBase() = default;
+
+      protected:
+	/**
+	 * Get a shared pointer to the current object. It's used when we invoke
+	 * the user-defined callbacks on various events like accept/read/write
+	 * and we'd pass the shared_ptr reference to the callbacks such such
+	 * that they can invoke the writeToPeer and readFromPeer callback
+	 * handlers which implements the non-blocking read/write operation on
+	 * the underlying peer's socket
+	 *
+	 * @return Shared pointer to the event loop interface
+	 */
+	virtual std::shared_ptr<EventLoopBase<PeerState>>
+	getSharedPtr() noexcept = 0;
 };
 
 struct EpollEventDeleter {

--- a/blueth/net/Socket.hpp
+++ b/blueth/net/Socket.hpp
@@ -37,12 +37,13 @@ class Socket {
 	Domain _domain;
 	int _file_des{};
 	SockType _sock_type;
+	// @@@ Currently, it only supports IPv4
 	struct sockaddr_in _socket_sockaddr;
 	socklen_t _endpoint_sockaddr_len{};
 
       public:
-	Socket(const std::string &IP_addr, const std::uint16_t &port,
-	       int backlog, Domain communication_domain, SockType socket_type);
+	Socket(std::string IP_addr, std::uint16_t port, int backlog,
+	       Domain communication_domain, SockType socket_type);
 	Socket(const Socket &) = delete;
 	Socket(Socket &&);
 	Socket() = default;
@@ -101,10 +102,9 @@ inline int Socket::acceptOnce() {
 			&_endpoint_sockaddr_len);
 }
 
-inline Socket::Socket(const std::string &IP_addr, const std::uint16_t &port,
-		      int backlog, Domain communication_domain,
-		      SockType socket_type)
-    : _IP_addr{IP_addr}, _port{port}, _endpoint_backlog{backlog},
+inline Socket::Socket(std::string IP_addr, std::uint16_t port, int backlog,
+		      Domain communication_domain, SockType socket_type)
+    : _IP_addr{std::move(IP_addr)}, _port{port}, _endpoint_backlog{backlog},
       _domain{communication_domain}, _sock_type{socket_type} {
 	m_create_socket();
 }

--- a/ci/make_run_tests.pl
+++ b/ci/make_run_tests.pl
@@ -18,7 +18,8 @@ my $TEST_BINS = {
 	http => "./tests/test-http/test_http",
 	net_one => "./tests/test-net/sync_net_stream_client",
 	thread_pool_executor => "./tests/test-concurrency/thread_pool_exec",
-	codec => "./tests/test-codec/test_codec"
+	codec => "./tests/test-codec/test_codec",
+	async_event_loop => "./tests/test-concurrency/async_event_loop_test"
 };
 if(-d $BUILD_DIR){
 	print "Build dir already exists, remove that first\n"; exit(1);
@@ -38,8 +39,7 @@ sub build_binary {
 
 sub run_tests {
 	my $test_cmd = ${$TEST_BINS}{container}." && ".${$TEST_BINS}{io}." && ".${$TEST_BINS}{http}." && ".${$TEST_BINS}{thread_pool_executor};
-	$test_cmd .= " && ".${$TEST_BINS}{codec};
-	$test_cmd .= " && ".${$TEST_BINS}{net_one} unless defined $ENV{REMOTE_TEST_RUN};
+	$test_cmd .= " && ".${$TEST_BINS}{codec}." && ".${$TEST_BINS}{net_one}." && ".${$TEST_BINS}{async_event_loop};
 	my $exit_code = system($test_cmd);
 	return $exit_code;
 }

--- a/tests/test-concurrency/CMakeLists.txt
+++ b/tests/test-concurrency/CMakeLists.txt
@@ -18,8 +18,12 @@ add_executable(
 target_link_libraries(
 	async_event_loop_test
 	libblueth
+	gtest
+	gtest_main
+	pthread
 	)
 
+set(CMAKE_CXX_FLAGS "-Wall -g3 -ggdb -fno-omit-frame-pointer")
 add_executable(
 	thread_pool_exec
 	test-ThreadPoolExecutor.cpp


### PR DESCRIPTION
It took a while, but we'd implemented it successfully. The issue was
that we are not having a return statement on the function where we get a
std::shared_ptr to the event-loop implementation. It's been solved,
anyway. We'd need to consider all warnings as errors in future with a
GCC flag, it's better for sanitazation of the codebase.